### PR TITLE
Optional velocity matching loss + whole-sequence batching for the sequence aligner

### DIFF
--- a/examples/align_to_SMPL_seq.py
+++ b/examples/align_to_SMPL_seq.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     parser.add_argument('-o', '--out_dir', type=str, help='Output directory', default='output')
     parser.add_argument('-F', '--force-recompute', help='Force recomputation of the alignment', action='store_true')
     parser.add_argument('-D', '--debug', help='Only run the fit on the first minibach to test', action='store_true')
-    parser.add_argument('-B', '--batch_size', type=int, help='Batch size', default=3000)
+    parser.add_argument('-B', '--batch_size', type=int, help='Batch size (0 to fit the whole sequence as a single batch)', default=3000)
     parser.add_argument('-w', '--watch_frame', type=int, help='Frame of the batch to display', default=0)
     parser.add_argument('--gender', type=str, help='Gender of the subject (only needed if not provided with smpl_data_path)', default='female')
     parser.add_argument('-m', '--export_meshes', choices=[None, 'mesh', 'pickle'], default=None, 
@@ -51,7 +51,7 @@ if __name__ == '__main__':
     skel_seq = skel_fitter.run_fit(smpl_seq['trans'], 
                                smpl_seq['betas'], 
                                smpl_seq['poses'], 
-                               batch_size = args.batch_size,
+                               batch_size = args.batch_size if args.batch_size > 0 else None,
                                skel_data_init=skel_data_init, 
                                force_recompute=args.force_recompute,
                                debug=args.debug,

--- a/skel/alignment/aligner.py
+++ b/skel/alignment/aligner.py
@@ -11,7 +11,7 @@ See https://skel.is.tue.mpg.de/license.html for licensing and contact informatio
 import math
 import os
 import pickle
-from skel.alignment.losses import compute_anchor_pose, compute_anchor_trans, compute_pose_loss, compute_scapula_loss, compute_spine_loss, compute_time_loss, pretty_loss_print
+from skel.alignment.losses import compute_anchor_pose, compute_anchor_trans, compute_pose_loss, compute_scapula_loss, compute_spine_loss, compute_time_loss, compute_velocity_matching_loss, gaussian_kernel_1d, pretty_loss_print, smooth_time
 from skel.alignment.utils import location_to_spheres, to_numpy, to_params, to_torch
 import torch
 from tqdm import trange
@@ -247,8 +247,19 @@ class SkelFitter(object):
                                           line_search_fn=cfg.line_search_fn,  
                                           tolerance_change=cfg.tolerance_change)
                 
-            poses_init = poses.detach().clone()               
+            poses_init = poses.detach().clone()
             trans_init = trans.detach().clone()
+
+            # Precompute the smoothed target vertex velocity for the velocity matching
+            # loss. The target is constant across the LBFGS iterations of this stage, so
+            # we smooth it once here (see compute_velocity_matching_loss).
+            self.target_vel_smoothed = None
+            self.vel_kernel = None
+            if cfg.get('l_velocity_loss', 0.0) > 0 and verts.shape[0] > 1:
+                self.vel_kernel = gaussian_kernel_1d(cfg.get('velocity_smoothing_sigma', 2.0),
+                                                     verts.device, verts.dtype)
+                self.target_vel_smoothed = smooth_time((verts[1:] - verts[:-1]).detach(),
+                                                       self.vel_kernel)
 
             def closure():
                 optimizer.zero_grad()
@@ -384,7 +395,14 @@ class SkelFitter(object):
             # Adjust the losses of all the pose regularizations sub losses with the pose_reg_factor value
             for key in ['scapula_loss', 'spine_loss', 'pose_loss']:
                 loss_dict[key] = cfg.pose_reg_factor * loss_dict[key]
-                
+
+        # Velocity matching (optional, off by default): match the fitted vertices'
+        # frame-to-frame velocity to the target vertices' velocity. Unlike time_loss,
+        # which is a zero-velocity prior, this does not damp genuine motion.
+        if cfg.get('l_velocity_loss', 0.0) > 0 and getattr(self, 'target_vel_smoothed', None) is not None:
+            loss_dict['velocity_loss'] = cfg.l_velocity_loss * compute_velocity_matching_loss(
+                output.skin_verts, self.target_vel_smoothed, self.vel_kernel)
+
         return loss_dict
 
     def _fstep_plot(self, output, cfg, verts, anat_joints):

--- a/skel/alignment/aligner.py
+++ b/skel/alignment/aligner.py
@@ -68,7 +68,18 @@ class SkelFitter(object):
             debug=False,
             watch_frame=0,
             freevert_mesh=None):
-        """Align SKEL to a SMPL sequence."""
+        """Align SKEL to a SMPL sequence.
+
+        batch_size: number of frames optimized jointly. Pass None to fit the whole
+        sequence as a single batch. Large batches (hundreds of frames) make much better
+        use of a modern GPU (small batches are kernel-launch bound) and avoid pose
+        discontinuities at the batch boundaries, where the next batch is only connected
+        to the previous one through its initialization. The whole sequence then shares
+        one LBFGS budget instead of one per batch, so if you lower num_steps/max_iter
+        in the config for speed, scale max_iter back up (~3x) when moving from
+        batch_size=20 to whole-sequence batches. The default config's budget is large
+        enough for either.
+        """
 
         self.nb_frames = poses_in.shape[0]
         self.watch_frame = watch_frame
@@ -84,7 +95,9 @@ class SkelFitter(object):
         # Initialize SKEL torch params
         body_params = self._init_params(betas_in, poses_in, trans_in, skel_data_init)
     
-        # We cut the whole sequence in batches for parallel optimization  
+        # We cut the whole sequence in batches for parallel optimization
+        if batch_size is None:
+            batch_size = self.nb_frames
         if batch_size > self.nb_frames:
             batch_size = self.nb_frames
             print('Batch size is larger than the number of frames. Setting batch size to {}'.format(batch_size))

--- a/skel/alignment/config.yaml
+++ b/skel/alignment/config.yaml
@@ -1,5 +1,13 @@
 # Optimization config file. In 'optim_steps' we define each optimization steps. 
 # Each step inherit and overwrite the parameters of the previous step."""
+#
+# Note on batch_size (run_fit) vs the iteration budget: large batches (hundreds of
+# frames, or batch_size=None for the whole sequence) are much faster per frame on
+# modern GPUs and avoid pose discontinuities at batch boundaries, but the whole
+# sequence then shares one LBFGS budget instead of one per batch. If you lower
+# num_steps/max_iter for speed, scale max_iter back up (~3x) when moving from
+# batch_size=20 to whole-sequence batches. When comparing batch sizes, never hold
+# the per-batch budget fixed — that systematically favors small batches.
 
 keepalive_meshviewer: false
 optim_steps:

--- a/skel/alignment/config.yaml
+++ b/skel/alignment/config.yaml
@@ -18,6 +18,13 @@ optim_steps:
     l_scapula_loss: 0.0
     l_spine_loss: 0.0
     l_pose_loss: 0.0
+    # Optional velocity matching term (0 = off, exact previous behavior). Matches the
+    # fitted vertices' frame-to-frame velocity to the target vertices' velocity instead
+    # of assuming zero velocity like l_time_loss. Both velocities are smoothed with the
+    # same temporal Gaussian (sigma in frames), see losses.compute_velocity_matching_loss.
+    # A weight of 300 works well for sequences where the source subject is moving.
+    l_velocity_loss: 0.0
+    velocity_smoothing_sigma: 2.0
   - description: Adjust the upper limbs pose
     lr: 0.1
     max_iter: 20

--- a/skel/alignment/losses.py
+++ b/skel/alignment/losses.py
@@ -39,6 +39,50 @@ def compute_time_loss(poses):
     time_loss = torch.linalg.norm(pose_delta, ord=2)
     return time_loss
 
+def gaussian_kernel_1d(sigma, device, dtype):
+    """Normalized 1D Gaussian kernel (radius ~2.5 sigma) for temporal smoothing."""
+
+    radius = max(1, int(round(2.5 * float(sigma))))
+    taps = torch.arange(-radius, radius + 1, device=device, dtype=dtype)
+    kernel = torch.exp(-0.5 * (taps / float(sigma)) ** 2)
+    return kernel / kernel.sum()
+
+def smooth_time(x, kernel):
+    """Smooth a (T, ...) tensor along the time axis with a 1D kernel, replicate padding."""
+
+    radius = (kernel.shape[0] - 1) // 2
+    if x.shape[0] <= 1 or radius == 0:
+        return x
+    padded = torch.cat([x[:1].expand(radius, *x.shape[1:]),
+                        x,
+                        x[-1:].expand(radius, *x.shape[1:])], dim=0)
+    out = torch.zeros_like(x)
+    for i in range(kernel.shape[0]):
+        out = out + kernel[i] * padded[i : i + x.shape[0]]
+    return out
+
+def compute_velocity_matching_loss(verts_fitted, target_vel_smoothed, kernel):
+    """Match the fitted skin vertices' frame-to-frame velocity to the target vertices' velocity.
+
+    The time loss is a zero-velocity prior on the poses: it damps jitter but also damps
+    genuine motion. This term instead matches the *observed* velocity of the target mesh,
+    so it is equivalent to a zero-velocity prior on a still subject and unbiased on a
+    moving one.
+
+    Both sides are smoothed with the SAME temporal Gaussian kernel. The target velocity
+    must be smoothed because per-frame estimation flutter should not be matched; smoothing
+    the fitted velocity with the same kernel makes the blur cancel between the two sides,
+    so motion faster than the kernel is arbitrated by the data term instead of being
+    suppressed. (Smoothing the target only penalizes genuinely fast motion.)
+
+    verts_fitted: (T, V, 3) fitted skin vertices for the batch.
+    target_vel_smoothed: (T-1, V, 3) pre-smoothed target vertex velocity, see smooth_time.
+    kernel: the 1D Gaussian kernel the target velocity was smoothed with.
+    """
+
+    vel_fitted = smooth_time(verts_fitted[1:] - verts_fitted[:-1], kernel)
+    return torch.nn.functional.mse_loss(vel_fitted, target_vel_smoothed)
+
 def pretty_loss_print(loss_dict):
     # Pretty print the loss on the form loss val | loss1 val1 | loss2 val2 
     # Start with the total loss


### PR DESCRIPTION
## Motivation

We use `SkelFitter.run_fit` in production to fit SKEL to SMPL sequences coming
from a multi-camera markerless capture platform, and found two temporal
behaviors of the aligner worth improving:

1. **The temporal prior assumes the subject is not moving.** `l_time_loss` is
   an MSE on the frame-to-frame pose deltas — a zero-velocity prior (the code
   comment notes it "avoids unstable hips orientationZ"). It does suppress
   jitter, but on a moving subject it also damps genuine motion: the fit
   systematically undershoots fast movement when the weight is high enough to
   help.

2. **Batch boundaries leave visible seams.** The sequence is cut into
   fixed-size batches, and consecutive batches are only connected through the
   next batch's initialization. With the default `batch_size=20` we measured
   pose discontinuities concentrated exactly at the boundaries (numbers below).

Both changes are strictly opt-in: with the default config and default
arguments, behavior is bit-for-bit identical to master.

## What changed

### Commit 1 — velocity matching loss (opt-in)

New term in `_fitting_loss`, controlled by two new config knobs
(`l_velocity_loss`, default **0.0** = exact current behavior, and
`velocity_smoothing_sigma`, default 2.0 frames):

- MSE between the **fitted skin vertices'** frame-to-frame deltas and the
  **target SMPL vertices'** frame-to-frame deltas.
- Both sides are smoothed with the **same** symmetric temporal Gaussian
  (sigma 2 frames → radius 5). The target velocity must be smoothed so the fit
  does not chase per-frame estimation flutter in the target; smoothing the
  fitted side with the same kernel makes the blur cancel between the two
  sides, so motion faster than the kernel is arbitrated by the vertex data
  term instead of being suppressed.
- The smoothed target velocity is precomputed once per optimization stage
  (it is constant across the LBFGS iterations), so the per-iteration cost is
  one delta + one small 1D convolution on the fitted side.

This is a strict generalization of the existing prior: on a still source the
target velocity is zero and the term reduces to a zero-velocity prior on the
fitted vertices; on a moving source it is unbiased instead of damping.

### Commit 2 — whole-sequence batching (opt-in)

- `run_fit(batch_size=None)` fits the entire sequence as a single batch;
  `examples/align_to_SMPL_seq.py` accepts `-B 0` for the same.
- Documented the interaction between batch size and the per-batch LBFGS
  budget in `config.yaml` (a whole-sequence batch shares one budget instead of
  one per batch — when comparing batch sizes, holding the per-batch budget
  fixed systematically favors small batches).
- The `run_fit` default (`batch_size=20`) is unchanged.

## Measurements

All numbers were measured on SMPL sequences from a multi-camera markerless
capture platform (RTX 4090, sequences of ~500 frames at 30 fps), fitting with
a reduced iteration budget (`num_steps=3`, `max_iter=9`) that we use for
throughput. Pose errors are rigid-aligned mean per-vertex errors against our
platform's reference.

**Batch seams.** With `batch_size=20`, the largest frame-to-frame pose deltas
concentrate on batch boundaries: seam frame-pairs showed a max pose delta
~3.6× the non-seam pairs, and 100% of the top pose snaps in the clip landed on
seams.

**Whole-sequence batching.** Fitting the whole clip as one batch with the
per-stage `max_iter` scaled up ~3× was **~6× faster wall-clock** than
`batch_size=20` at the reduced budget (the GPU is saturated by the large
batch, while small batches are kernel-launch bound), with equal or better pose
accuracy and zero seams.
**Velocity matching.** At `l_velocity_loss: 300` (the same scale as the
default `l_verts_loose: 600`), sigma 2 frames, the term replaced our use of
the zero-velocity prior with no jitter regression and no motion damping.
Symmetric smoothing is load-bearing: an earlier version that smoothed only
the target regressed a high range-of-motion clip's pose error from 46 mm to
60 mm (genuinely fast motion was being compared against a blurred target and
got damped); smoothing both sides with the same kernel removed the regression
entirely.

## Limitations

- The measurements above are from our platform's capture data, not from AMASS;
  we did not re-benchmark on public sequences. The repository's own sample
  sequence (`examples/samples/amass_seq/CMU_01_01.npz`) reproduces the
  mechanics (see reproduction notes), and the seam/speed effects should
  reproduce on any AMASS-style sequence longer than a few batches.
- The `~6×` wall-clock figure was measured at our reduced iteration budget
 ; with
  the default config's larger budget the relative speedup will differ, though
  the direction (large batches saturate the GPU) holds.
- `l_velocity_loss: 300` is a recommendation from our data; the right weight
  may differ on other sources. The default keeps it off.

## Reproduction

```bash
# Baseline vs whole-sequence (seams + wall-clock):
python examples/align_to_SMPL_seq.py examples/samples/amass_seq/CMU_01_01.npz --gender female -B 20 -o out_b20 -F
python examples/align_to_SMPL_seq.py examples/samples/amass_seq/CMU_01_01.npz --gender female -B 0  -o out_whole -F

# Velocity matching: copy skel/alignment/config.yaml, set l_velocity_loss: 300,
# and pass it with --config.
```

Both features default off; the default config and default arguments preserve
current behavior exactly.

